### PR TITLE
fix: cross-filesystem rename failure on Linux + skill invocation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,26 @@ Example plugin.json:
 /plugin validate .
 ```
 
+### Skill not working with slash command
+
+When invoking skills from external projects, you must use the full namespaced format:
+
+```bash
+# Correct - use the full namespace
+/claude-codex:multi-ai Add user authentication
+
+# Wrong - bare skill name doesn't work from external projects
+/multi-ai Add user authentication
+```
+
+The bare skill name (e.g., `/multi-ai`) only works within the plugin's internal context. When using the plugin from your own project, always prefix with `claude-codex:`.
+
+**Alternative:** You can also ask Claude naturally without using slash commands:
+
+> "Use the multi-ai pipeline to add user authentication"
+
+Claude will recognize this and invoke the appropriate skill.
+
 ## Documentation
 
 For detailed guides, visit our [Wiki](https://github.com/Z-M-Huang/claude-codex/wiki):

--- a/plugins/claude-codex/scripts/setup.sh
+++ b/plugins/claude-codex/scripts/setup.sh
@@ -57,7 +57,7 @@ save_preference() {
   if [[ -f "$PREFERENCES_FILE" ]]; then
     cp "$PREFERENCES_FILE" "$PREFERENCES_FILE.tmp"
     $JSON_TOOL set "$PREFERENCES_FILE.tmp" "workflow_mode=$mode" "configured_at@=now"
-    mv "$PREFERENCES_FILE.tmp" "$PREFERENCES_FILE"
+    cp "$PREFERENCES_FILE.tmp" "$PREFERENCES_FILE" && rm -f "$PREFERENCES_FILE.tmp"
   else
     cat > "$PREFERENCES_FILE" << EOF
 {

--- a/plugins/claude-codex/scripts/state-manager.sh
+++ b/plugins/claude-codex/scripts/state-manager.sh
@@ -132,7 +132,7 @@ set_state() {
       "updated_at@=now"
   fi
 
-  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  cp "${STATE_FILE}.tmp" "$STATE_FILE" && rm -f "${STATE_FILE}.tmp"
 }
 
 # Get previous state (used for error recovery)
@@ -157,14 +157,14 @@ check_state_readable() {
 increment_iteration() {
   cp "$STATE_FILE" "${STATE_FILE}.tmp"
   $JSON_TOOL set "${STATE_FILE}.tmp" "+iteration" "updated_at@=now"
-  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  cp "${STATE_FILE}.tmp" "$STATE_FILE" && rm -f "${STATE_FILE}.tmp"
 }
 
 # Reset iteration (for new task)
 reset_iteration() {
   cp "$STATE_FILE" "${STATE_FILE}.tmp"
   $JSON_TOOL set "${STATE_FILE}.tmp" "iteration:=0" "started_at@=now" "updated_at@=now"
-  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  cp "${STATE_FILE}.tmp" "$STATE_FILE" && rm -f "${STATE_FILE}.tmp"
 }
 
 # Note: awaiting_output functions removed - no longer needed with subagent architecture


### PR DESCRIPTION
## Summary
- Replace `mv` with `cp` + `rm` pattern in shell scripts to fix EXDEV error when source and target are on different filesystems
- Add troubleshooting section to README for skill namespace usage (`/claude-codex:skill-name` vs `/skill-name`)

Closes #1