### PR TITLE
feat: autonomous pipeline with interactive user-story phase

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-AI orchestration plugins for Claude Code",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "plugins": [
     {
       "name": "claude-codex",
       "source": "./plugins/claude-codex",
       "description": "Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus → codex)",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "author": {
         "name": "Z-M-Huang"
       },

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Example plugin.json:
 ```json
 {
   "name": "your-plugin-name",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "What your plugin does",
   "author": { "name": "Your Name" },
   "skills": "./skills/"

--- a/plugins/claude-codex/.claude-plugin/plugin.json
+++ b/plugins/claude-codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-codex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus → codex)",
   "author": {
     "name": "Z-M-Huang",

--- a/plugins/claude-codex/docs/schemas/plan-review.schema.json
+++ b/plugins/claude-codex/docs/schemas/plan-review.schema.json
@@ -9,6 +9,16 @@
       "enum": ["approved", "needs_changes"],
       "description": "Overall plan review decision"
     },
+    "needs_clarification": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, pauses autonomous pipeline to ask user for clarification on ambiguous requirements"
+    },
+    "clarification_questions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Questions to ask user when needs_clarification is true"
+    },
     "summary": {
       "type": "string",
       "description": "Brief overall assessment of the plan"

--- a/plugins/claude-codex/docs/schemas/review-result.schema.json
+++ b/plugins/claude-codex/docs/schemas/review-result.schema.json
@@ -6,6 +6,16 @@
       "type": "string",
       "enum": ["approved", "needs_changes", "rejected"]
     },
+    "needs_clarification": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, pauses autonomous pipeline to ask user for clarification on ambiguous requirements"
+    },
+    "clarification_questions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Questions to ask user when needs_clarification is true"
+    },
     "summary": {
       "type": "string",
       "description": "Brief overall assessment"

--- a/plugins/claude-codex/pipeline.config.json
+++ b/plugins/claude-codex/pipeline.config.json
@@ -1,9 +1,10 @@
 {
-  "version": "1.0.5",
+  "version": "1.0.6",
 
   "autonomy": {
-    "mode": "semi-autonomous",
+    "mode": "autonomous",
     "approvalPoints": {
+      "userStory": true,
       "planning": false,
       "implementation": false,
       "review": false,
@@ -12,7 +13,8 @@
     "maxAutoRetries": 3,
     "reviewLoopLimit": 10,
     "planReviewLoopLimit": 10,
-    "codeReviewLoopLimit": 15
+    "codeReviewLoopLimit": 15,
+    "pauseOnlyOn": ["needs_clarification", "review_loop_exceeded", "unrecoverable_error"]
   },
 
   "models": {

--- a/plugins/claude-codex/skills/multi-ai/SKILL.md
+++ b/plugins/claude-codex/skills/multi-ai/SKILL.md
@@ -2,107 +2,205 @@
 name: multi-ai
 description: Start the multi-AI pipeline with a given request. Cleans up old task files and guides through plan → review → implement → review workflow.
 plugin-scoped: true
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Skill, AskUserQuestion
 ---
 
-# Multi-AI Pipeline Command
+# Multi-AI Pipeline Command (Autonomous Mode)
 
-You are starting the multi-AI pipeline. Follow this process exactly.
+You are starting the multi-AI pipeline in **autonomous mode**. This means:
 
-**Note:** Scripts are located at `${CLAUDE_PLUGIN_ROOT}/scripts/`. The `.task/` directory is created in your project at `${CLAUDE_PROJECT_DIR}/.task/`.
+1. **User interaction happens FIRST** during requirements gathering
+2. **Everything after is automated** - no pauses between reviews
+3. **Only pause for**: `needs_clarification`, review loop exceeded, or unrecoverable errors
 
-## Step 1: Clean Up Previous Task
+**Scripts location:** `${CLAUDE_PLUGIN_ROOT}/scripts/`
+**Task directory:** `${CLAUDE_PROJECT_DIR}/.task/`
 
-First, reset the pipeline state:
+---
+
+## Phase 1: Requirements Gathering (Interactive)
+
+### Step 1: Clean Up Previous Task
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator.sh" reset
 ```
 
-This removes old `.task/` files and sets state to `idle`.
+### Step 2: Set State and Gather Requirements
 
-## Step 2: Create User Request
-
-Write the user's request to `.task/user-request.txt`:
+Set the state to requirements_gathering before invoking /user-story:
 
 ```bash
-mkdir -p "${CLAUDE_PROJECT_DIR:-.}/.task"
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set requirements_gathering ""
 ```
 
-Then write the request content to `.task/user-request.txt`.
+**Invoke /user-story** to interactively gather and clarify requirements with the user.
 
-## Step 3: Set Initial State
+This skill will:
+- Ask clarifying questions
+- Resolve ambiguities
+- Get user approval on requirements
+- Write `.task/user-story.json` and `.task/user-request.txt`
+
+**WAIT** for user approval before continuing. This is the only interactive phase.
+
+---
+
+## Phase 2: Autonomous Planning
+
+Once requirements are approved, proceed autonomously.
+
+### Step 3: Set State and Create Plan
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set plan_drafting ""
 ```
 
-## Step 4: Create Initial Plan
-
-Create `.task/plan.json` with:
+Create `.task/plan.json` based on the approved user story:
 - `id`: "plan-YYYYMMDD-HHMMSS"
-- `title`: Short descriptive title
-- `description`: What the user wants
-- `requirements`: List of requirements
+- `title`: From user story
+- `description`: From user story requirements
+- `requirements`: From user story functional requirements
 - `created_at`: ISO8601 timestamp
 - `created_by`: "claude"
 
-## Step 5: Transition to Refining
+### Step 4: Refine Plan
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set plan_refining "$(bun ${CLAUDE_PLUGIN_ROOT}/scripts/json-tool.ts get .task/plan.json .id)"
 ```
 
-## Step 6: Refine Plan
+Research the codebase and create `.task/plan-refined.json` with:
+- Technical approach
+- Files to modify/create
+- Potential challenges
 
-Create `.task/plan-refined.json` with technical details:
-- Research the codebase
-- Add `technical_approach`
-- Add `files_to_modify` and `files_to_create`
-- Add `potential_challenges`
+### Step 5: Automated Plan Review Loop
 
-## Step 7: Sequential Plan Reviews
+Run the automated review loop (see "Automated Review Loop" section below).
 
-Run reviews in order. Fix issues after each before continuing:
+**DO NOT** wait for user confirmation between reviews. Fix issues automatically and continue.
 
-1. **Invoke /review-sonnet** → If issues, fix them
-2. **Invoke /review-opus** → If issues, fix them
-3. **Invoke /review-codex** → If issues, fix and restart from step 1
+---
 
-When all approve, continue.
+## Phase 3: Autonomous Implementation
 
-## Step 8: Implement
+### Step 6: Implement
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set implementing "$(bun ${CLAUDE_PLUGIN_ROOT}/scripts/json-tool.ts get .task/plan-refined.json .id)"
+```
 
 **Invoke /implement-sonnet** to implement the approved plan.
 
-This skill will:
-- Write the code following the approved plan
-- Add tests
-- Output to `.task/impl-result.json`
+### Step 7: Automated Code Review Loop
 
-## Step 9: Sequential Code Reviews
+Run the automated review loop (see "Automated Review Loop" section below).
 
-Run reviews in order. Fix issues after each before continuing:
+**DO NOT** wait for user confirmation between reviews. Fix issues automatically and continue.
 
-1. **Invoke /review-sonnet** → If issues, fix them
-2. **Invoke /review-opus** → If issues, fix them
-3. **Invoke /review-codex** → If issues, fix and restart from step 1
+---
 
-When all approve, continue.
+## Phase 4: Completion
 
-## Step 10: Complete
+### Step 8: Mark Complete
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/state-manager.sh" set complete "$(bun ${CLAUDE_PLUGIN_ROOT}/scripts/json-tool.ts get .task/plan-refined.json .id)"
 ```
 
-Report success to the user.
+Report success to the user with a summary of:
+- What was implemented
+- Files changed
+- Tests added
+- Any notes or follow-up items
+
+---
+
+## Automated Review Loop
+
+This is the core automation. Execute reviews sequentially, fixing issues automatically.
+
+**Read limits from `${CLAUDE_PLUGIN_ROOT}/pipeline.config.json`:**
+- For **Plan Reviews**: use `autonomy.planReviewLoopLimit` (default: 10)
+- For **Code Reviews**: use `autonomy.codeReviewLoopLimit` (default: 15)
+
+```
+LOOP_COUNT = 0
+MAX_LOOPS = <phase-specific limit from config>
+
+WHILE LOOP_COUNT < MAX_LOOPS:
+
+    1. INVOKE /review-sonnet
+       READ .task/review-sonnet.json
+       IF status == "needs_changes":
+           FIX all issues listed in the review
+           (update plan or code as appropriate)
+
+    2. INVOKE /review-opus
+       READ .task/review-opus.json
+       IF status == "needs_changes":
+           FIX all issues listed in the review
+
+    3. INVOKE /review-codex
+       READ .task/review-codex.json
+       IF status == "approved":
+           BREAK (exit loop - all reviews passed)
+       IF status == "needs_changes":
+           FIX all issues listed in the review
+           LOOP_COUNT += 1
+           CONTINUE (restart from sonnet)
+
+    IF any review has needs_clarification == true:
+        PAUSE and ask user (use AskUserQuestion)
+        After user responds, continue loop
+
+IF LOOP_COUNT >= MAX_LOOPS:
+    PAUSE - inform user review loop exceeded limit
+    Ask if they want to continue or abort
+```
+
+### Key Rules for Automated Fixes
+
+1. **Accept ALL reviewer feedback** - no debate, just fix
+2. **Fix thoroughly** - address root causes, not just symptoms
+3. **Don't introduce new issues** while fixing
+4. **Run tests after code fixes** if tests exist
+5. **Update plan documentation** if architecture changes
+
+### When to Pause (Exceptions)
+
+Only pause the autonomous flow when one of the conditions in `autonomy.pauseOnlyOn` from `pipeline.config.json` is met:
+
+1. **needs_clarification**: A reviewer sets `needs_clarification: true` with questions that require user input
+2. **review_loop_exceeded**: Exceeded the phase-specific loop limit without approval
+3. **unrecoverable_error**: Build failures, missing dependencies, etc. that can't be auto-resolved
+
+For these cases, use `AskUserQuestion` to get user input, then continue.
 
 ---
 
 ## Important Rules
 
-- Follow this process exactly - no shortcuts
-- Fix ALL issues raised by reviewers before continuing
-- If codex rejects, restart the review cycle from sonnet
-- Keep the user informed of progress at each major step
+- **Autonomous by default**: Don't ask for confirmation between steps
+- **Fix and continue**: When reviewers find issues, fix them and keep going
+- **Only pause when truly stuck**: Ambiguity, decisions, or exceeded limits
+- **Inform, don't ask**: Tell the user what you're doing, don't ask if you should do it
+- **Complete the full cycle**: Don't stop until complete or legitimately blocked
+
+---
+
+## Progress Reporting
+
+While running autonomously, provide brief status updates:
+
+```
+Planning phase complete. Starting plan reviews...
+✓ Sonnet review: approved
+✓ Opus review: 2 issues found, fixing...
+✓ Opus review: approved (after fixes)
+✓ Codex review: approved
+Plan approved. Starting implementation...
+```
+
+This keeps the user informed without requiring their input.

--- a/plugins/claude-codex/skills/review-opus/SKILL.md
+++ b/plugins/claude-codex/skills/review-opus/SKILL.md
@@ -65,6 +65,8 @@ Write to `.task/review-opus.json`:
   "model": "opus",
   "reviewed_at": "ISO8601",
   "summary": "Deep assessment",
+  "needs_clarification": false,
+  "clarification_questions": [],
   "issues": [
     {
       "severity": "error|warning|suggestion",
@@ -87,6 +89,7 @@ Write to `.task/review-opus.json`:
 - Poor test quality → status: `needs_changes`
 - 2+ `warning` → status: `needs_changes`
 - Only `suggestion` → status: `approved`
+- **Ambiguous requirements** that cannot be resolved by code analysis → set `needs_clarification: true` and populate `clarification_questions`
 
 ## After Review
 

--- a/plugins/claude-codex/skills/review-sonnet/SKILL.md
+++ b/plugins/claude-codex/skills/review-sonnet/SKILL.md
@@ -61,6 +61,8 @@ Write to `.task/review-sonnet.json`:
   "model": "sonnet",
   "reviewed_at": "ISO8601",
   "summary": "Brief assessment",
+  "needs_clarification": false,
+  "clarification_questions": [],
   "issues": [
     {
       "severity": "error|warning|suggestion",
@@ -79,6 +81,7 @@ Write to `.task/review-sonnet.json`:
 - Any `error` severity → status: `needs_changes`
 - 2+ `warning` severity → status: `needs_changes`
 - Only `suggestion` → status: `approved`
+- **Ambiguous requirements** that cannot be resolved by code analysis → set `needs_clarification: true` and populate `clarification_questions`
 
 ## After Review
 

--- a/plugins/claude-codex/skills/user-story/SKILL.md
+++ b/plugins/claude-codex/skills/user-story/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: user-story
+description: Gather and clarify requirements before autonomous pipeline execution. Interactive phase for user input.
+plugin-scoped: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+# User Story Gathering Phase
+
+This skill handles the **interactive requirements gathering phase** before the autonomous pipeline runs. This is the ONLY phase where user interaction is expected.
+
+## Purpose
+
+- Gather complete requirements from the user
+- Ask clarifying questions to resolve ambiguity
+- Get user approval on the finalized requirements
+- Write approved requirements for autonomous processing
+
+## Process
+
+### Step 1: Analyze the Request
+
+Read the user's initial request and identify:
+- Core functionality requested
+- Potential ambiguities or unclear requirements
+- Missing information needed for implementation
+- Technical decisions that need user input
+
+### Step 2: Ask Clarifying Questions
+
+Use the `AskUserQuestion` tool to gather any missing information. Focus on:
+
+1. **Functional Requirements**
+   - What should the feature do?
+   - What are the expected inputs/outputs?
+   - What are the edge cases to handle?
+
+2. **Technical Preferences**
+   - Any preferred libraries or approaches?
+   - Compatibility requirements?
+   - Performance expectations?
+
+3. **Scope Boundaries**
+   - What is explicitly OUT of scope?
+   - Minimum viable vs. nice-to-have features?
+
+### Step 3: Summarize Requirements
+
+Create a clear requirements summary and present it to the user:
+
+```
+## Requirements Summary
+
+### Core Requirements
+- [List main features/functionality]
+
+### Technical Approach
+- [Preferred technologies/patterns]
+
+### Scope
+- In scope: [what will be implemented]
+- Out of scope: [what won't be implemented]
+
+### Acceptance Criteria
+- [How to verify the feature works]
+```
+
+### Step 4: Get User Approval
+
+Ask the user to confirm the requirements are correct:
+
+```
+Does this requirements summary accurately capture what you want?
+
+If yes, I'll proceed with the autonomous pipeline:
+1. Planning phase (with automated reviews)
+2. Implementation phase (with automated reviews)
+3. Final report
+
+You won't need to intervene unless there's an unresolvable issue.
+```
+
+### Step 5: Write Approved Requirements
+
+Once approved, write to `.task/user-story.json`:
+
+```json
+{
+  "id": "story-YYYYMMDD-HHMMSS",
+  "title": "Short descriptive title",
+  "original_request": "The user's original request text",
+  "requirements": {
+    "functional": ["req1", "req2"],
+    "technical": ["tech1", "tech2"],
+    "acceptance_criteria": ["criterion1", "criterion2"]
+  },
+  "scope": {
+    "in_scope": ["item1", "item2"],
+    "out_of_scope": ["item1", "item2"]
+  },
+  "clarifications": [
+    {"question": "Q1?", "answer": "A1"},
+    {"question": "Q2?", "answer": "A2"}
+  ],
+  "approved_at": "ISO8601",
+  "approved_by": "user"
+}
+```
+
+Also write the original request to `.task/user-request.txt`.
+
+### Step 6: Signal Ready for Autonomous Processing
+
+After writing the approved requirements, output:
+
+```
+Requirements approved and saved. Starting autonomous pipeline...
+```
+
+The multi-ai skill will then take over and run autonomously.
+
+---
+
+## Important Notes
+
+- This is the ONLY phase where back-and-forth with the user is expected
+- Ask all necessary questions BEFORE getting approval
+- Once approved, the pipeline should run autonomously
+- If you truly cannot determine something, mark it in requirements as TBD and note it will be decided during planning


### PR DESCRIPTION
## Summary

- **Add `/user-story` skill** for interactive requirements gathering at the start of the pipeline
- **Autonomous execution** after requirements are approved - no more confirmation prompts between review stages
- **Add `needs_clarification` field** to review schemas so reviewers can pause the pipeline when user input is truly needed
- **Phase-specific loop limits** - `planReviewLoopLimit` (10) and `codeReviewLoopLimit` (15) from config
- **Codex review improvements** - prompts now request clarification questions when requirements are ambiguous, and subsequent reviews branch on plan vs code type

## Problem

~80% of pipeline runs required user confirmation to proceed between stages (e.g., after sonnet review → before opus review). Most of these were unnecessary - the pipeline should auto-fix reviewer issues and continue.

## Solution

1. **Interactive phase first**: `/user-story` gathers and clarifies requirements upfront
2. **Autonomous after approval**: Pipeline runs without pauses, auto-fixing issues
3. **Pause only when needed**: 
   - `needs_clarification` - reviewer found ambiguity requiring user decision
   - `review_loop_exceeded` - hit configured loop limit
   - `unrecoverable_error` - build failures, missing deps

## Files Changed

| Category | Files |
|----------|-------|
| New skill | `skills/user-story/SKILL.md` |
| Schemas | `plan-review.schema.json`, `review-result.schema.json` |
| Skills | `multi-ai/SKILL.md`, `review-sonnet/SKILL.md`, `review-opus/SKILL.md`, `review-codex/SKILL.md` |
| Docs | `CLAUDE.md`, `workflow.md` |
| Config | `pipeline.config.json`, `orchestrator.sh` |

## Test plan

- [x] `test-paths.sh` - all 13 tests pass