### PR TITLE
feat: TDD-driven Ralph Loop for autonomous implementation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,24 +4,24 @@
     "name": "Z-M-Huang"
   },
   "metadata": {
-    "description": "Multi-AI orchestration plugins for Claude Code",
-    "version": "1.0.9"
+    "description": "Multi-AI orchestration plugins for Claude Code with TDD-driven Ralph Loop",
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "claude-codex",
       "source": "./plugins/claude-codex",
-      "description": "Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus → codex)",
-      "version": "1.0.9",
+      "description": "Multi-AI orchestration pipeline with TDD-driven Ralph Loop (sonnet → opus → codex)",
+      "version": "1.1.0",
       "author": {
         "name": "Z-M-Huang"
       },
       "homepage": "https://github.com/Z-M-Huang/claude-codex",
       "repository": "https://github.com/Z-M-Huang/claude-codex",
       "license": "MIT",
-      "keywords": ["multi-ai", "code-review", "orchestration", "pipeline"],
+      "keywords": ["multi-ai", "code-review", "orchestration", "pipeline", "ralph-loop", "tdd"],
       "category": "development",
-      "tags": ["ai", "review", "automation", "pipeline"],
+      "tags": ["ai", "review", "automation", "pipeline", "tdd"],
       "skills": "./skills/"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -78,17 +78,21 @@ After installation, use skills with the plugin namespace:
 
 ### claude-codex
 
-Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus → codex).
+Multi-AI orchestration pipeline with **TDD-driven Ralph Loop** (sonnet → opus → codex).
+
+**New in v1.1.0:** Ralph Loop mode - implementation phase automatically iterates until all tests pass AND all reviews approve. No more manual intervention!
 
 **Skills included:**
 
 | Skill              | Model             | Purpose                                     |
 | ------------------ | ----------------- | ------------------------------------------- |
 | `multi-ai`         | -                 | Pipeline entry point (starts full workflow) |
+| `user-story`       | -                 | Gather requirements + TDD criteria          |
 | `implement-sonnet` | Claude Sonnet 4.5 | Code implementation with main context       |
 | `review-sonnet`    | Claude Sonnet 4.5 | Fast review (code + security + tests)       |
 | `review-opus`      | Claude Opus 4.5   | Deep review (architecture + subtle issues)  |
 | `review-codex`     | Codex CLI         | Final review via OpenAI Codex               |
+| `cancel-loop`      | -                 | Emergency stop for Ralph Loop               |
 
 ## Recommended Subscriptions
 
@@ -107,26 +111,38 @@ Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus
 
 This command:
 
-1. Cleans up previous task files
-2. Creates and refines a plan
-3. Runs sequential reviews (sonnet → opus → codex)
-4. Implements the code
-5. Runs sequential reviews (sonnet → opus → codex)
-6. Marks complete
+1. **Requirements** (interactive) - Gathers requirements + TDD test criteria
+2. **Planning** (semi-interactive) - Creates plan, only asks if conflicts detected
+3. **Implementation** (Ralph Loop) - Iterates until tests pass + reviews approve
+4. **Complete** - Reports results
 
-### Sequential Review Flow
+### Ralph Loop: TDD-Driven Implementation
 
-Reviews run **sequentially** - each model reviews only ONCE per cycle:
+The implementation phase uses the **Ralph Wiggum technique** - an autonomous iteration loop:
 
 ```
-Plan/Code → review-sonnet → fix → review-opus → fix → review-codex → fix (restart)
+┌──────────────────────────────────────────┐
+│  RALPH LOOP (until max iterations)       │
+│  ┌────────────────────────────────────┐  │
+│  │ 1. Implement/fix code              │  │
+│  │ 2. Review (sonnet → opus → codex)  │  │
+│  │ 3. Run tests                       │  │
+│  │                                    │  │
+│  │ IF all reviews pass AND tests pass │  │
+│  │    → EXIT with completion promise  │  │
+│  │ ELSE                               │  │
+│  │    → continue loop                 │  │
+│  └────────────────────────────────────┘  │
+└──────────────────────────────────────────┘
 ```
 
 **Key benefits:**
 
-- Each model provides unique perspective without re-reviewing
-- Progressive refinement (fast → deep → final)
-- Token-efficient (forked context isolation)
+- **Autonomous iteration** - No manual intervention needed
+- **TDD completion** - Tests define "done"
+- **Multi-AI review** - Every iteration gets reviewed by all three models
+- **Safety limits** - Max iterations prevents infinite loops
+- **Cancel anytime** - `/cancel-loop` for emergency stop
 
 ## Marketplace Structure
 

--- a/plugins/claude-codex/.claude-plugin/plugin.json
+++ b/plugins/claude-codex/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-codex",
-  "version": "1.0.9",
-  "description": "Multi-AI orchestration pipeline with sequential review workflow (sonnet → opus → codex)",
+  "version": "1.1.0",
+  "description": "Multi-AI orchestration pipeline with TDD-driven Ralph Loop (sonnet → opus → codex)",
   "author": {
     "name": "Z-M-Huang",
     "url": "https://github.com/Z-M-Huang"
@@ -16,7 +16,9 @@
     "pipeline",
     "sonnet",
     "opus",
-    "codex"
+    "codex",
+    "ralph-loop",
+    "tdd"
   ],
   "skills": "./skills/"
 }

--- a/plugins/claude-codex/CLAUDE.md
+++ b/plugins/claude-codex/CLAUDE.md
@@ -1,97 +1,127 @@
-# Claude Code - Multi-AI Pipeline Project
+# Claude Code - Multi-AI Pipeline with Ralph Loop
 
-> **IMPORTANT**: This project uses an **autonomous pipeline** with skill-based sequential reviews. User interaction happens ONLY during the initial requirements gathering phase. After that, the pipeline runs autonomously, fixing reviewer issues automatically.
+> **IMPORTANT**: This project uses a **TDD-driven Ralph Loop** for implementation. User interaction happens during requirements gathering and optionally during planning. The implementation phase uses the Ralph Wiggum technique - iterating automatically until tests pass AND all reviews approve.
 
 ## Path Reference
 
-When this plugin is installed, paths are resolved as follows:
-
 | Variable | Purpose | Example |
 |----------|---------|---------|
-| `${CLAUDE_PLUGIN_ROOT}` | Plugin installation directory (scripts, docs, configs) | `~/.claude/plugins/claude-codex/` |
-| `${CLAUDE_PROJECT_DIR}` | Your project directory (task state files) | `/path/to/your/project/` |
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin installation directory | `~/.claude/plugins/claude-codex/` |
+| `${CLAUDE_PROJECT_DIR}` | Your project directory | `/path/to/your/project/` |
 
-**Important:** The `.task/` directory is always created in your **project directory**, not the plugin directory. This allows the plugin to work across multiple projects without conflicts.
+**Important:** The `.task/` directory is created in your **project directory**, not the plugin directory.
 
 ## Architecture Overview
 
 ```
-Multi-AI Pipeline (Autonomous Mode)
+Multi-AI Pipeline with Ralph Loop
   │
-  ├── Phase 1: Requirements Gathering (INTERACTIVE)
-  │     └── /user-story → Clarify requirements, get user approval
+  ├── Phase 1: Requirements (INTERACTIVE)
+  │     └── /user-story → Gather requirements + TDD criteria
   │
-  ├── Phase 2: Planning (AUTONOMOUS)
-  │     ├── Create initial plan
-  │     ├── Refine with technical details
-  │     └── Automated review loop (fix issues, no user pauses)
+  ├── Phase 2: Planning (SEMI-INTERACTIVE)
+  │     ├── Create plan with test commands & risk assessment
+  │     ├── Review loop (autonomous)
+  │     └── Prompt user ONLY if conflicts detected
   │
-  ├── Phase 3: Implementation (AUTONOMOUS)
-  │     ├── /implement-sonnet → Write code
-  │     └── Automated review loop (fix issues, no user pauses)
+  ├── Phase 3: Implementation (RALPH LOOP)
+  │     ├── IF simple mode → single implementation cycle
+  │     └── IF ralph-loop mode:
+  │           ┌─────────────────────────────────┐
+  │           │  LOOP until max iterations:     │
+  │           │  1. Implement/fix code          │
+  │           │  2. Review (sonnet→opus→codex)  │
+  │           │  3. Run tests                   │
+  │           │  IF all pass → EXIT             │
+  │           │  ELSE → continue loop           │
+  │           └─────────────────────────────────┘
   │
   └── Phase 4: Completion
-        └── Report results to user
+        └── Report results
 ```
 
 ---
 
-## When User Asks to Implement Something
-
-Start with `/multi-ai`:
+## Quick Start
 
 ```
 /multi-ai [description of what you want]
 ```
 
 The pipeline will:
-1. **Gather requirements** (interactive) - Ask clarifying questions, get approval
-2. **Plan autonomously** - Create and refine plan, auto-fix review issues
-3. **Implement autonomously** - Write code, auto-fix review issues
-4. **Report results** - Summary of what was done
-
-**The user only interacts during step 1.** Everything after runs automatically.
+1. **Gather requirements** (interactive) - Including TDD criteria
+2. **Plan** (semi-interactive) - Only asks if conflicts detected
+3. **Implement** (ralph loop) - Iterates until tests pass + reviews approve
+4. **Complete** - Report results
 
 ---
 
 ## Skills
 
-Located in `skills/` (plugin root level for `/plugin install` support):
-
 | Skill | Purpose | Model | Phase |
 |-------|---------|-------|-------|
 | `/multi-ai` | Start pipeline (entry point) | - | All |
-| `/user-story` | Gather requirements (interactive) | - | Requirements |
+| `/user-story` | Gather requirements + TDD criteria | - | Requirements |
 | `/implement-sonnet` | Code implementation | sonnet | Implementation |
 | `/review-sonnet` | Fast review | sonnet | Review |
 | `/review-opus` | Deep review | opus | Review |
-| `/review-codex` | Final review | codex | Review |
+| `/review-codex` | Final review (Codex CLI) | codex | Review |
+| `/cancel-loop` | Cancel active ralph loop | - | Emergency |
 
-### Automated Review Loop
+---
 
-Reviews run **automatically** without user pauses:
+## Implementation Modes
 
+### Simple Mode
+For small, straightforward changes:
+- Single implementation pass
+- One review cycle
+- Tests run once
+- No looping
+
+### Ralph Loop Mode (Default for complex features)
+For features requiring iteration:
+- Stop hook intercepts session exit
+- Reviews + tests run each iteration
+- Loops until ALL pass:
+  - Sonnet review: approved
+  - Opus review: approved
+  - Codex review: approved
+  - All test commands: exit code 0
+- Max iterations safety limit (default: 10)
+
+---
+
+## TDD Criteria
+
+During requirements gathering, define:
+
+```json
+{
+  "test_criteria": {
+    "commands": ["npm test", "npm run lint"],
+    "success_pattern": "passed|✓",
+    "failure_pattern": "FAILED|Error"
+  },
+  "implementation": {
+    "mode": "ralph-loop",
+    "max_iterations": 10
+  }
+}
 ```
-LOOP until all reviews pass (or max loops reached):
-  │
-  ├── /review-sonnet → If issues, FIX them automatically
-  ├── /review-opus   → If issues, FIX them automatically
-  └── /review-codex  → If approved: DONE
-                       If issues: FIX and restart loop
-```
 
-**Key change from semi-autonomous mode:**
-- NO user confirmation between reviews
-- Issues are fixed automatically
-- Only pause when truly stuck (ambiguity, exceeded limits, unrecoverable errors)
+---
 
-### When Pipeline Pauses
+## Risk Assessment
 
-The pipeline ONLY pauses for user input when:
+Planning phase detects potential infinite loop risks:
 
-1. **needs_clarification** - Missing information that requires user decision
-2. **review_loop_exceeded** - Exceeded max review cycles (configurable)
-3. **unrecoverable_error** - Build failures, missing deps that can't be auto-resolved
+1. **Test vs Review conflicts** - Test requires something reviews might reject
+2. **Linter vs Style conflicts** - Auto-fixes conflict with coding standards
+3. **Missing infrastructure** - Test dependencies not available
+4. **Circular dependencies** - Fixes create new review issues
+
+If risks detected → prompt user for decision.
 
 ---
 
@@ -101,173 +131,174 @@ The pipeline ONLY pauses for user input when:
 idle
   ↓
 requirements_gathering (/user-story - INTERACTIVE)
-  │  Ask questions, get user approval
   ↓ [approved]
-plan_drafting (create initial plan)
+plan_drafting
   ↓
-plan_refining (refine + AUTOMATED review loop)
-  │  sonnet → fix → opus → fix → codex
-  │  Loop until approved (no user pauses)
+plan_refining (+ risk assessment)
+  ↓ [conflicts? → ask user]
+plan_reviewing (review loop)
   ↓ [all approved]
-implementing (/implement-sonnet + AUTOMATED review loop)
-  │  sonnet → fix → opus → fix → codex
-  │  Loop until approved (no user pauses)
-  ↓ [all approved]
+implementing (simple) OR implementing_loop (ralph)
+  │
+  │ [ralph loop mode]
+  │  ┌──────────────────────────┐
+  │  │ implement → review → test│
+  │  │ IF all pass → exit       │
+  │  │ ELSE → loop              │
+  │  └──────────────────────────┘
+  ↓
 complete
 ```
 
 ---
 
-## Shared Knowledge
+## Loop State File
 
-Read these docs before any work:
-- `${CLAUDE_PLUGIN_ROOT}/docs/standards.md` - Coding standards and review criteria
-- `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md` - Pipeline process and output formats
+During ralph loop, `.task/loop-state.json` tracks progress:
+
+```json
+{
+  "active": true,
+  "iteration": 3,
+  "max_iterations": 10,
+  "completion_promise": "<promise>IMPLEMENTATION_COMPLETE</promise>",
+  "plan_path": ".task/plan-refined.json",
+  "started_at": "2026-01-22T10:00:00Z"
+}
+```
+
+To cancel loop manually: `rm .task/loop-state.json` or `/cancel-loop`
 
 ---
 
 ## Output Formats
 
-### User Story Output
-Write to: `.task/user-story.json`
-
+### User Story (`.task/user-story.json`)
 ```json
 {
   "id": "story-YYYYMMDD-HHMMSS",
-  "title": "Short descriptive title",
-  "original_request": "The user's original request text",
+  "title": "Feature title",
   "requirements": {
-    "functional": ["req1", "req2"],
-    "technical": ["tech1", "tech2"],
-    "acceptance_criteria": ["criterion1", "criterion2"]
+    "functional": ["req1"],
+    "technical": ["tech1"],
+    "acceptance_criteria": ["criterion1"]
   },
-  "scope": {
-    "in_scope": ["item1", "item2"],
-    "out_of_scope": ["item1", "item2"]
+  "test_criteria": {
+    "commands": ["npm test"],
+    "success_pattern": "passed"
   },
-  "clarifications": [
-    {"question": "Q1?", "answer": "A1"}
-  ],
+  "implementation": {
+    "mode": "ralph-loop",
+    "max_iterations": 10
+  },
   "approved_at": "ISO8601",
   "approved_by": "user"
 }
 ```
 
-### Plan Creation Output
-Write to: `.task/plan.json`
-
+### Plan Refined (`.task/plan-refined.json`)
 ```json
 {
   "id": "plan-YYYYMMDD-HHMMSS",
-  "title": "Short descriptive title",
-  "description": "What the user wants to achieve",
-  "requirements": ["req1", "req2"],
-  "created_at": "ISO8601",
-  "created_by": "claude"
-}
-```
-
-### Plan Refinement Output
-Write to: `.task/plan-refined.json`
-
-```json
-{
-  "id": "plan-001",
   "title": "Feature title",
-  "description": "What the user wants",
-  "requirements": ["req 1", "req 2"],
-  "technical_approach": "Detailed description of how to implement",
-  "files_to_modify": ["path/to/existing/file.ts"],
-  "files_to_create": ["path/to/new/file.ts"],
-  "dependencies": ["any new packages needed"],
-  "estimated_complexity": "low|medium|high",
-  "potential_challenges": [
-    "Challenge 1 and how to address it",
-    "Challenge 2 and how to address it"
-  ],
-  "refined_by": "claude",
-  "refined_at": "ISO8601"
+  "technical_approach": "How to implement",
+  "files_to_modify": ["path/to/file.ts"],
+  "implementation": {
+    "mode": "ralph-loop",
+    "max_iterations": 10,
+    "skill": "implement-sonnet"
+  },
+  "test_plan": {
+    "commands": ["npm test", "npm run lint"],
+    "success_pattern": "passed|✓",
+    "run_after_review": true
+  },
+  "risk_assessment": {
+    "infinite_loop_risks": [],
+    "conflicts_detected": [],
+    "requires_user_decision": false
+  },
+  "completion_promise": "<promise>IMPLEMENTATION_COMPLETE</promise>"
 }
 ```
 
-### Implementation Output
-Write to: `.task/impl-result.json`
+---
 
+## Hooks
+
+The plugin uses a Stop hook for the ralph loop:
+
+**`hooks/hooks.json`:**
 ```json
 {
-  "status": "completed|failed|needs_clarification",
-  "summary": "What was implemented",
-  "files_changed": ["path/to/file.ts"],
-  "tests_added": ["path/to/test.ts"],
-  "questions": []
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/implementation-stop-hook.js"
+      }]
+    }]
+  }
 }
 ```
 
----
+The hook:
+1. Checks if loop is active (`.task/loop-state.json`)
+2. **Reads** existing review files (does NOT run review skills)
+3. **Runs** test commands from plan (in project directory)
+4. Checks success/failure patterns from plan
+5. Blocks exit if criteria not met, re-feeds prompt
+6. Allows exit when all criteria pass
 
-## Review Handling (Autonomous)
-
-### Automated Review Process
-
-For both planning and implementation phases, the review loop runs **automatically**:
-
-1. **Invoke /review-sonnet**
-   - If `needs_changes`: FIX issues automatically, continue to step 2
-   - If `approved`: continue to step 2
-
-2. **Invoke /review-opus**
-   - If `needs_changes`: FIX issues automatically, continue to step 3
-   - If `approved`: continue to step 3
-
-3. **Invoke /review-codex**
-   - If `approved`: proceed to next phase
-   - If `needs_changes`: FIX issues automatically, **restart from step 1**
-
-### Auto-Fix Rules
-
-When fixing reviewer feedback:
-- Accept ALL feedback without debate
-- Fix root causes, not symptoms
-- Run tests after code changes
-- Update documentation if architecture changes
-- Don't introduce new issues while fixing
-
----
-
-## Strict Loop-Until-Pass Model
-
-- Reviews loop until all three approve (or max loops reached)
-- No debate mechanism - accept all review feedback
-- Fix ALL issues raised by any reviewer
-- Codex rejection restarts the full review cycle
-- **No user pauses** - only pause for genuine blockers
+**IMPORTANT:** You must run `/review-sonnet`, `/review-opus`, `/review-codex` yourself before attempting to exit. The hook only verifies the review file contents.
 
 ---
 
 ## Configuration
 
-See `pipeline.config.json` for settings:
+`pipeline.config.json`:
 
 ```json
 {
+  "version": "1.1.0",
   "autonomy": {
-    "mode": "autonomous",
+    "mode": "ralph-loop",
     "approvalPoints": {
       "userStory": true,
       "planning": false,
-      "implementation": false,
-      "review": false,
-      "commit": true
+      "implementation": false
     },
-    "pauseOnlyOn": ["needs_clarification", "review_loop_exceeded", "unrecoverable_error"],
-    "reviewLoopLimit": 10,
+    "pauseOnlyOn": ["needs_clarification", "review_loop_exceeded", "conflicts_detected"],
     "planReviewLoopLimit": 10,
     "codeReviewLoopLimit": 15
+  },
+  "ralphLoop": {
+    "defaultMode": "ralph-loop",
+    "defaultMaxIterations": 10,
+    "completionPromise": "<promise>IMPLEMENTATION_COMPLETE</promise>",
+    "testSuccessExitCode": 0
   }
 }
 ```
 
-**Config field usage:**
-- `approvalPoints` - Documents which phases require user approval (enforced by skill instructions)
-- `pauseOnlyOn` - Lists conditions that pause autonomous execution (checked in multi-ai skill)
-- `planReviewLoopLimit` / `codeReviewLoopLimit` - Phase-specific loop limits (read by multi-ai skill)
+---
+
+## Emergency Controls
+
+If the loop is stuck:
+
+1. **Cancel command:** `/cancel-loop`
+2. **Delete state file:** `rm .task/loop-state.json`
+3. **Max iterations:** Loop auto-stops at limit
+
+---
+
+## Completion Criteria
+
+All must be true to exit ralph loop:
+
+1. ✓ `.task/review-sonnet.json` → status: "approved"
+2. ✓ `.task/review-opus.json` → status: "approved"
+3. ✓ `.task/review-codex.json` → status: "approved"
+4. ✓ All test commands → exit code 0
+5. ✓ Output contains completion promise

--- a/plugins/claude-codex/hooks/hooks.json
+++ b/plugins/claude-codex/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Claude Codex implementation loop stop hook for TDD-driven ralph loop",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/implementation-stop-hook.js"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-codex/hooks/implementation-stop-hook.js
+++ b/plugins/claude-codex/hooks/implementation-stop-hook.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Implementation Stop Hook for Claude Codex Ralph Loop
+ *
+ * This hook intercepts session exit during the implementation loop phase.
+ * It checks if all completion criteria are met (reviews pass + tests pass).
+ * If not, it blocks exit and re-feeds the implementation prompt.
+ *
+ * IMPORTANT: This hook READS existing review files - it does NOT run the review skills.
+ * The multi-ai skill is responsible for invoking review skills before attempting to exit.
+ *
+ * Based on the Ralph Wiggum technique from Anthropic's official plugins.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Get directories from environment
+const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.dirname(__dirname);
+const TASK_DIR = path.join(PROJECT_DIR, '.task');
+const LOOP_STATE_FILE = path.join(TASK_DIR, 'loop-state.json');
+const PLAN_FILE = path.join(TASK_DIR, 'plan-refined.json');
+const CONFIG_FILE = path.join(PLUGIN_ROOT, 'pipeline.config.json');
+
+/**
+ * Safely read and parse JSON file
+ */
+function readJson(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write JSON file
+ */
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+/**
+ * Run a command and return { exitCode, output }
+ */
+function runCommand(cmd, cwd) {
+  try {
+    const output = execSync(cmd, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 300000, // 5 minute timeout
+    });
+    return { exitCode: 0, output };
+  } catch (error) {
+    return {
+      exitCode: error.status || 1,
+      output: error.stdout || error.stderr || error.message,
+    };
+  }
+}
+
+/**
+ * Main hook logic
+ */
+function main() {
+  // Check if loop state file exists
+  const loopState = readJson(LOOP_STATE_FILE);
+  if (!loopState) {
+    // No active loop, allow exit
+    process.exit(0);
+  }
+
+  // Check if loop is active
+  if (loopState.active !== true) {
+    // Loop not active, allow exit
+    process.exit(0);
+  }
+
+  // Read iteration info
+  const iteration = loopState.iteration || 0;
+  const maxIterations = loopState.max_iterations || 10;
+  const completionPromise = loopState.completion_promise || '<promise>IMPLEMENTATION_COMPLETE</promise>';
+
+  // Read config settings
+  const config = readJson(CONFIG_FILE);
+  const testSuccessExitCode = config?.ralphLoop?.testSuccessExitCode ?? 0;
+
+  // Check if max iterations reached
+  if (iteration >= maxIterations) {
+    console.log(JSON.stringify({
+      decision: 'allow',
+      systemMessage: `Max iterations reached (${iteration}/${maxIterations}). Loop terminated.`
+    }));
+    // Deactivate the loop
+    loopState.active = false;
+    writeJson(LOOP_STATE_FILE, loopState);
+    process.exit(0);
+  }
+
+  // Check completion criteria
+  let reviewsPassed = true;
+  let testsPassed = false; // Default to false - must have tests to pass
+  let reviewStatus = '';
+  let testStatus = '';
+
+  // Check review files
+  const reviewFiles = ['review-sonnet.json', 'review-opus.json', 'review-codex.json'];
+  for (const reviewFile of reviewFiles) {
+    const reviewPath = path.join(TASK_DIR, reviewFile);
+    const review = readJson(reviewPath);
+    if (review) {
+      const status = review.status || 'unknown';
+      if (status !== 'approved') {
+        reviewsPassed = false;
+        reviewStatus += `${reviewFile.replace('.json', '')}: ${status}; `;
+      }
+    } else {
+      reviewsPassed = false;
+      reviewStatus += `${reviewFile.replace('.json', '')}: not run; `;
+    }
+  }
+
+  // Check test results if plan exists
+  const plan = readJson(PLAN_FILE);
+  if (plan) {
+    const testCommands = plan.test_plan?.commands || [];
+    const successPattern = plan.test_plan?.success_pattern || '';
+    const failurePattern = plan.test_plan?.failure_pattern || '';
+
+    if (testCommands.length > 0) {
+      testsPassed = true; // Assume pass, flip on failure
+
+      for (const cmd of testCommands) {
+        if (!cmd) continue;
+
+        // Run test command in project directory
+        const result = runCommand(cmd, PROJECT_DIR);
+
+        // Check exit code
+        if (result.exitCode !== testSuccessExitCode) {
+          testsPassed = false;
+          testStatus += `${cmd}: failed (exit code ${result.exitCode}); `;
+          continue;
+        }
+
+        // Check failure pattern if defined
+        if (failurePattern && new RegExp(failurePattern).test(result.output)) {
+          testsPassed = false;
+          testStatus += `${cmd}: failure pattern detected; `;
+          continue;
+        }
+
+        // Check success pattern if defined
+        if (successPattern && !new RegExp(successPattern).test(result.output)) {
+          testsPassed = false;
+          testStatus += `${cmd}: success pattern not found; `;
+        }
+      }
+    } else {
+      // No test commands defined - TDD violation
+      testsPassed = false;
+      testStatus = 'No test commands defined in plan (TDD required); ';
+    }
+  } else {
+    // No plan file
+    testsPassed = false;
+    testStatus = 'Plan file missing - cannot verify tests; ';
+  }
+
+  // Check if completion criteria met
+  if (reviewsPassed && testsPassed) {
+    // All criteria met, allow exit
+    loopState.active = false;
+    writeJson(LOOP_STATE_FILE, loopState);
+    process.exit(0);
+  }
+
+  // Increment iteration
+  const newIteration = iteration + 1;
+  loopState.iteration = newIteration;
+  writeJson(LOOP_STATE_FILE, loopState);
+
+  // Build continuation prompt
+  const prompt = `Continue implementing based on the plan at .task/plan-refined.json
+
+**Iteration:** ${newIteration} of ${maxIterations}
+
+**Review Status:** (checked existing review files)
+${reviewStatus || 'All reviews approved'}
+
+**Test Status:** (run from project directory)
+${testStatus || 'All tests passed'}
+
+**What to do:**
+1. Fix all issues identified above
+2. Run /review-sonnet, /review-opus, /review-codex (in that order)
+3. Run the test commands from the plan
+4. Attempt to exit - the hook will check criteria again
+
+**Completion Criteria:**
+- All review files must have status: "approved"
+- All test commands must pass (exit code ${testSuccessExitCode})
+
+When complete, output: ${completionPromise}`;
+
+  // Block exit and re-feed the prompt
+  console.log(JSON.stringify({
+    decision: 'block',
+    reason: prompt,
+    systemMessage: `Ralph loop iteration ${newIteration}/${maxIterations}: Reviews passed: ${reviewsPassed}, Tests passed: ${testsPassed}`
+  }));
+
+  process.exit(2); // Exit code 2 = blocking error
+}
+
+main();

--- a/plugins/claude-codex/pipeline.config.json
+++ b/plugins/claude-codex/pipeline.config.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.9",
+  "version": "1.1.0",
 
   "autonomy": {
-    "mode": "autonomous",
+    "mode": "ralph-loop",
     "approvalPoints": {
       "userStory": true,
       "planning": false,
@@ -14,7 +14,14 @@
     "reviewLoopLimit": 10,
     "planReviewLoopLimit": 10,
     "codeReviewLoopLimit": 15,
-    "pauseOnlyOn": ["needs_clarification", "review_loop_exceeded", "unrecoverable_error"]
+    "pauseOnlyOn": ["needs_clarification", "review_loop_exceeded", "conflicts_detected", "unrecoverable_error"]
+  },
+
+  "ralphLoop": {
+    "defaultMode": "ralph-loop",
+    "defaultMaxIterations": 10,
+    "completionPromise": "<promise>IMPLEMENTATION_COMPLETE</promise>",
+    "testSuccessExitCode": 0
   },
 
   "models": {

--- a/plugins/claude-codex/skills/cancel-loop/SKILL.md
+++ b/plugins/claude-codex/skills/cancel-loop/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: cancel-loop
+description: Cancel the active Ralph implementation loop. Use when you want to stop the iterative process.
+plugin-scoped: true
+allowed-tools: Read, Write, Bash
+---
+
+# Cancel Implementation Loop
+
+This skill cancels an active Ralph implementation loop, allowing the session to exit normally.
+
+## When to Use
+
+- The loop is stuck or making no progress
+- You want to manually intervene
+- You've decided to take a different approach
+- Max iterations warning appeared and you want to stop
+
+## What It Does
+
+1. Reads the current loop state from `.task/loop-state.json`
+2. Sets `active: false` to deactivate the loop
+3. Reports the final state (iterations completed, last status)
+
+## Usage
+
+Simply invoke:
+```
+/cancel-loop
+```
+
+## Process
+
+### Step 1: Check Loop State
+
+Read `.task/loop-state.json` to see current state:
+
+```bash
+cat "${CLAUDE_PROJECT_DIR}/.task/loop-state.json" 2>/dev/null || echo "No active loop found"
+```
+
+### Step 2: Deactivate Loop
+
+If loop is active, update the state file:
+
+```bash
+if [[ -f "${CLAUDE_PROJECT_DIR}/.task/loop-state.json" ]]; then
+    # Use bun/node to update JSON
+    bun -e "
+        const fs = require('fs');
+        const path = '${CLAUDE_PROJECT_DIR}/.task/loop-state.json';
+        const state = JSON.parse(fs.readFileSync(path, 'utf8'));
+        state.active = false;
+        state.cancelled_at = new Date().toISOString();
+        state.cancelled_by = 'user';
+        fs.writeFileSync(path, JSON.stringify(state, null, 2));
+        console.log('Loop cancelled at iteration', state.iteration);
+    "
+fi
+```
+
+### Step 3: Report Status
+
+Tell the user:
+- How many iterations were completed
+- Last review status
+- Last test status
+- What files were changed
+
+### Step 4: Clean Exit
+
+The session can now exit normally since the loop is deactivated.
+
+## Alternative: Manual Cancellation
+
+You can also cancel the loop manually by:
+
+1. **Delete the state file:**
+   ```bash
+   rm "${CLAUDE_PROJECT_DIR}/.task/loop-state.json"
+   ```
+
+2. **Or edit it directly:**
+   ```bash
+   # Set active to false
+   bun -e "
+       const fs = require('fs');
+       const state = JSON.parse(fs.readFileSync('.task/loop-state.json'));
+       state.active = false;
+       fs.writeFileSync('.task/loop-state.json', JSON.stringify(state, null, 2));
+   "
+   ```
+
+## Output
+
+After cancellation, report:
+
+```
+Loop cancelled.
+
+Status:
+- Iterations completed: 3 of 10
+- Last review: Sonnet approved, Opus needs_changes, Codex not run
+- Last tests: 2 passed, 1 failed
+
+The session will now exit normally.
+To resume, run /multi-ai with your request again.
+```

--- a/plugins/claude-codex/skills/user-story/SKILL.md
+++ b/plugins/claude-codex/skills/user-story/SKILL.md
@@ -178,6 +178,29 @@ The feature will be complete when:
 Are these the right success criteria?
 ```
 
+**Chunk 5: Test-Driven Completion (TDD Criteria)**
+```
+## Test Plan
+
+To verify the implementation is complete, we'll run:
+
+**Test Commands:**
+- `[test command 1]` - [what it verifies]
+- `[test command 2]` - [what it verifies]
+
+**Success Indicators:**
+- All tests pass (exit code 0)
+- [Additional success criteria like coverage threshold]
+
+**Implementation Mode:**
+- [ ] Simple (single implementation + review cycle)
+- [x] Ralph Loop (iterative until tests pass + reviews approve)
+
+**Max Iterations:** 10 (safety limit for ralph loop)
+
+Does this test plan look right? Any commands to add or remove?
+```
+
 **Ask clarifying questions** during any chunk if something is unclear. You can loop back to previous chunks if needed.
 
 ### Step 5: Final Approval
@@ -223,6 +246,16 @@ Once approved, write to `.task/user-story.json`:
   "scope": {
     "in_scope": ["item1", "item2"],
     "out_of_scope": ["item1", "item2"]
+  },
+  "test_criteria": {
+    "commands": ["npm test", "npm run lint"],
+    "success_pattern": "passed|✓|All tests passed",
+    "failure_pattern": "FAILED|Error|failed"
+  },
+  "implementation": {
+    "mode": "ralph-loop",
+    "max_iterations": 10,
+    "skill": "implement-sonnet"
   },
   "clarifications": [
     {"question": "Q1?", "answer": "A1"},


### PR DESCRIPTION
## Summary

- Implements the **Ralph Wiggum technique** for autonomous TDD-driven development
- Pipeline now iterates automatically until all tests pass AND all reviews approve
- Cross-platform Stop hook (JavaScript/Bun) for Windows/macOS/Linux support

## Changes

### New Features
- **TDD criteria gathering** in user-story skill (test commands, success/failure patterns)
- **Ralph-loop mode** in multi-ai skill with two implementation modes: `simple` and `ralph-loop`
- **Stop hook** (`implementation-stop-hook.js`) that checks completion criteria on exit
- **Risk assessment** during planning to detect potential infinite loop conflicts
- **/cancel-loop skill** for emergency abort

### New Files
- `plugins/claude-codex/hooks/hooks.json` - Hook configuration
- `plugins/claude-codex/hooks/implementation-stop-hook.js` - Cross-platform stop hook
- `plugins/claude-codex/skills/cancel-loop/SKILL.md` - Emergency cancel skill

### Modified Files
- `skills/user-story/SKILL.md` - Added Chunk 5 for TDD criteria
- `skills/multi-ai/SKILL.md` - Rewritten for ralph-loop support
- `CLAUDE.md` - Updated architecture documentation
- `pipeline.config.json` - Added `ralphLoop` config section
- Version bumped to **1.1.0**

## How It Works

```
┌──────────────────────────────────────────┐
│  RALPH LOOP (until max iterations)       │
│  ┌────────────────────────────────────┐  │
│  │ 1. Implement/fix code              │  │
│  │ 2. Review (sonnet → opus → codex)  │  │
│  │ 3. Run tests                       │  │
│  │                                    │  │
│  │ IF all reviews pass AND tests pass │  │
│  │    → EXIT with completion promise  │  │
│  │ ELSE                               │  │
│  │    → continue loop                 │  │
│  └────────────────────────────────────┘  │
└──────────────────────────────────────────┘
```