### PR TITLE
fix: Codex review errors on Windows (#8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Multi-AI orchestration plugins for Claude Code with task-based pipeline enforcement",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "plugins": [
     {
       "name": "claude-codex",
       "source": "./plugins/claude-codex",
       "description": "Multi-AI orchestration pipeline with task-based enforcement pipeline (sonnet → opus → codex)",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "author": {
         "name": "Z-M-Huang"
       },

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Plugin Version
       description: Which version of Claude Codex are you using?
-      placeholder: "1.4.2"
+      placeholder: "1.4.3"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This command orchestrates specialized agents:
 
 ### Task-Based Pipeline Enforcement
 
-The pipeline uses **task dependencies**, **hook validation**, and **agent teams** (v1.4.2):
+The pipeline uses **task dependencies**, **hook validation**, and **agent teams** (v1.4.3):
 
 ```
 ┌────────────────────────────────────────────────────┐

--- a/plugins/claude-codex/.claude-plugin/plugin.json
+++ b/plugins/claude-codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-codex",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Multi-AI orchestration pipeline with Task-based enforcement and Codex final gate",
   "author": {
     "name": "Z-M-Huang",

--- a/plugins/claude-codex/CLAUDE.md
+++ b/plugins/claude-codex/CLAUDE.md
@@ -61,7 +61,7 @@ Multi-Session Orchestrator Pipeline (Task-Based Enforcement)
 
 ---
 
-## Team-Based Requirements Gathering (v1.4.2)
+## Team-Based Requirements Gathering (v1.4.3)
 
 Requirements gathering uses Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) to explore from multiple perspectives in parallel, producing richer user stories from the start.
 

--- a/plugins/claude-codex/agents/codex-reviewer.md
+++ b/plugins/claude-codex/agents/codex-reviewer.md
@@ -131,7 +131,7 @@ The script outputs JSON events to stdout. Check the final event:
 
 ### Codex Error (exit code 2)
 ```json
-{"event": "error", "phase": "codex_execution", "error": "auth_required|not_installed|execution_failed"}
+{"event": "error", "phase": "codex_execution", "error": "auth_required|not_installed|stdin_not_terminal|execution_failed"}
 ```
 
 ### Timeout (exit code 3)
@@ -230,6 +230,7 @@ You are a **thin wrapper**. You exist solely to invoke `codex-review.ts` via Bas
 - Do NOT manually manage session markers — the script handles it
 - Do NOT produce a "helpful" review when Codex is unavailable — report the error
 - Do NOT claim Codex approved/rejected without actually running the CLI
+- Do NOT test codex by running `codex "prompt"` — interactive mode requires a TTY. The wrapper script uses `codex exec --full-auto` which works without a TTY.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #8 — Codex review step fails on Windows with `stdin is not a terminal` and related issues.

- **Prompt ambiguity fix**: Review prompt now uses type-conditional instructions (`"Map each acceptance criterion to plan steps"` for plan, `"Verify implementation evidence"` for code) instead of a combined sentence that confused Codex into reviewing the plan during code reviews
- **Validation relaxation**: Approved reviews with empty `requirements_coverage.mapping` now pass validation (legitimate on resume or when Codex structures coverage differently)
- **TTY error detection**: New `stdin_not_terminal` error type with diagnostic message explaining the wrapper uses `codex exec --full-auto` and the agent should not run codex interactively
- **Agent anti-pattern**: Added explicit instruction to `codex-reviewer.md` not to test codex with `codex "prompt"` (interactive mode)

## Files Changed

| File | Change |
|------|--------|
| `plugins/claude-codex/scripts/codex-review.ts` | Prompt fix, error detection, validation relaxation |
| `plugins/claude-codex/agents/codex-reviewer.md` | Anti-pattern, error type docs |
| Version files | Bumped to v1.4.3 |